### PR TITLE
Fix resource loading path for UI5 board

### DIFF
--- a/feature-planning-board/webapp/index.html
+++ b/feature-planning-board/webapp/index.html
@@ -12,7 +12,8 @@
         data-sap-ui-async="true"
         data-sap-ui-onInit="module:sap/ui/core/ComponentSupport"
         data-sap-ui-resourceroots='{
-            "my.sapui5.featureboard": "./"
+            "my.sapui5.featureboard": "./",
+            "feature.planning.board": "./"
         }'>
     </script>
     <link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
## Summary
- update `index.html` so Feature Planning Board loads UI5 modules from the local source

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9bbedd8483319569480d2bc49e88