### PR TITLE
Fix headerToolbar prefix for Master view

### DIFF
--- a/feature-planning-board/webapp/view/Master.view.xml
+++ b/feature-planning-board/webapp/view/Master.view.xml
@@ -5,7 +5,7 @@
     xmlns:m="sap.m"
     xmlns:core="sap.ui.core">
     <m:Page id="masterPage">
-        <headerToolbar>
+        <m:headerToolbar>
             <m:Toolbar>
                 <m:Title text="Feature planning (sample)" level="H2" />
                 <m:ToolbarSpacer />
@@ -15,7 +15,7 @@
                 <m:Button text="FILTER" press="onFilterPress" tooltip="Filter" />
                 <m:SearchField width="15rem" liveChange="onSearch" />
             </m:Toolbar>
-        </headerToolbar>
+        </m:headerToolbar>
         <m:content>
             <TreeTable id="treeTable" rows="{/hierarchy}" selectionMode="Single" rowSelectionChange="onItemPress">
                 <columns>


### PR DESCRIPTION
## Summary
- fix the `<headerToolbar>` namespace so UI5 doesn't load a bogus `headerToolbar.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9ee9ed008331a6135a2a81639f90